### PR TITLE
Require CGI explicitly

### DIFF
--- a/lib/faster_s3_url/builder.rb
+++ b/lib/faster_s3_url/builder.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require 'cgi'
+
 module FasterS3Url
   # Signing algorithm based on Amazon docs at https://docs.aws.amazon.com/general/latest/gr/sigv4-signed-request-examples.html ,
   # as well as some interactive code reading of Aws::Sigv4::Signer


### PR DESCRIPTION
When I tried testing out the gem in Pry, I was getting `NameError: uninitialized constant FasterS3Url::Builder::CGI`.

The test suite wasn't catching this, as something in `rspec/core` is loading it on your behalf.