### PR TITLE
get tests running again

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,12 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## 1.1.0
+
+### Fixed
+
+- response-expires header format match recent AWS ruby SDK by using #httpdate https://github.com/jrochkind/faster_s3_url/pull/5

--- a/faster_s3_url.gemspec
+++ b/faster_s3_url.gemspec
@@ -27,6 +27,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   spec.add_development_dependency "aws-sdk-s3", "~> 1.81"
+  spec.add_development_dependency "nokogiri" # aws gem now has implicit dependency on an XML processor such as
   spec.add_development_dependency "timecop", "< 2"
   spec.add_development_dependency "benchmark-ips", "~> 2.8"
   #spec.add_development_dependency "kalibera" # for benchmark-ips :bootstrap stats option

--- a/lib/faster_s3_url/builder.rb
+++ b/lib/faster_s3_url/builder.rb
@@ -265,14 +265,13 @@ module FasterS3Url
     # Crazy kind of reverse engineered from aws-sdk-ruby,
     # for compatible handling of Expires header.
     #
-    # This honestly seems to violate the HTTP spec, the result will be that for
-    # an `response-expires` param, subsequent S3 response will include an Expires
-    # header in ISO8601 instead of HTTP-date format.... but for now we'll make
-    # our tests pass by behaving equivalently to aws-sdk-s3 anyway? filed
-    # with aws-sdk-s3: https://github.com/aws/aws-sdk-ruby/issues/2415
+    # Recent versions of ruby AWS SDK use "httpdate" format here, as a result of
+    # an issue we filed: https://github.com/aws/aws-sdk-ruby/issues/2415
     #
-    # Switch last line from `.utc.iso8601` to `.httpdate` if you want to be
-    # more correct than aws-sdk-s3?
+    # We match what recent AWS SDK does.
+    #
+    # Note while the AWS SDK source says "rfc 822", it's ruby #httpdate that matches
+    # rather than ruby #rfc822 (timezone should be `GMT` to match AWS SDK, not `-0000`)
     def convert_for_timestamp_shape(arg)
       return nil if arg.nil?
 
@@ -286,7 +285,7 @@ module FasterS3Url
         else
           Time.parse(arg.to_s)
       end
-      time_value.utc.iso8601
+      time_value.utc.httpdate
     end
   end
 end


### PR DESCRIPTION
Haven't touched this in a while, as usual I find that CI is not green. Let's fix. 

* aws gem now has implicit dependency on an XML processor such as nokogiri, add for dev
* response-expires header format match recent AWS ruby SDK with #httpdate