### PR TITLE
Only define local Storage#object_key if Shrine isn't already providing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - response-expires header format match recent AWS ruby SDK by using #httpdate https://github.com/jrochkind/faster_s3_url/pull/5
 
+- Only define local Storage#object_key if Shrine isn't already providing https://github.com/jrochkind/faster_s3_url/pull/7
 
 ### Changed
 

--- a/lib/faster_s3_url/shrine/storage.rb
+++ b/lib/faster_s3_url/shrine/storage.rb
@@ -61,7 +61,7 @@ module FasterS3Url
       end
 
       # For older shrine versions without it, we need this...
-      unless self.method_defined?(:object_key)
+      unless self.method_defined?(:object_key) || self.private_method_defined?(:object_key)
         def object_key(id)
           [*prefix, id].join("/")
         end


### PR DESCRIPTION
It is a private method in original Shrine superclass, which wasn't being caught by previous check

Did not actually harm anything to redefine it same way as Shrine does, but keep things neater. 
