### PR TITLE
Add `endpoint` option to `Builder`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+
+- Add `endpoint` option to `Builder` https://github.com/jrochkind/faster_s3_url/pull/10
+
 ## 1.1.0
 
 ### Fixed

--- a/lib/faster_s3_url/base_uri.rb
+++ b/lib/faster_s3_url/base_uri.rb
@@ -1,0 +1,73 @@
+# frozen_string_literal: true
+
+require 'uri'
+require 'ipaddr'
+
+module FasterS3Url
+  class BaseURI
+    def initialize(bucket_name:, region:, endpoint: nil, host: nil)
+      @bucket_name = bucket_name
+      @region = region
+      @endpoint = endpoint
+      @host_param = host
+    end
+
+    def ip?
+      @ip ||= begin
+        return false unless uri
+
+        IPAddr.new(uri.host)
+        true
+      rescue IPAddr::InvalidAddressError
+        false
+      end
+    end
+
+    def scheme
+      @scheme ||= uri&.scheme || 'https'
+    end
+
+    def host
+      @host ||= if endpoint
+        ip? ? uri.host : "#{bucket_name}.#{uri.host}"
+      elsif host_param
+        host_param
+      else
+        default_host(bucket_name)
+      end
+    end
+
+    def host_with_port
+      [
+        host,
+        port
+      ].compact.join(':')
+    end
+
+    private
+
+    attr_reader :bucket_name, :endpoint, :host_param, :region
+
+    def uri
+      @uri ||= if endpoint
+        URI.parse(endpoint)
+      end
+    end
+
+    def port
+      @port ||= if uri&.port && uri&.default_port != uri&.port
+        uri.port
+      end
+    end
+
+    def default_host(bucket_name)
+      if region == "us-east-1"
+        # use legacy one without region, as S3 seems to
+        "#{bucket_name}.s3.amazonaws.com".freeze
+      else
+        "#{bucket_name}.s3.#{region}.amazonaws.com".freeze
+      end
+    end
+
+  end
+end

--- a/lib/faster_s3_url/builder.rb
+++ b/lib/faster_s3_url/builder.rb
@@ -1,8 +1,7 @@
 # frozen_string_literal: true
 
 require 'cgi'
-require 'uri'
-require 'ipaddr'
+require 'faster_s3_url/base_uri'
 
 module FasterS3Url
   # Signing algorithm based on Amazon docs at https://docs.aws.amazon.com/general/latest/gr/sigv4-signed-request-examples.html ,
@@ -22,7 +21,7 @@ module FasterS3Url
 
     MAX_CACHED_SIGNING_KEYS = 5
 
-    attr_reader :bucket_name, :region, :host, :endpoint, :access_key_id
+    attr_reader :bucket_name, :region, :host, :access_key_id, :uri
 
     # @option params [String] :bucket_name required
     #
@@ -48,8 +47,8 @@ module FasterS3Url
     def initialize(bucket_name:, region:, access_key_id:, secret_access_key:, host: nil, endpoint: nil, default_public: true, cache_signing_keys: false)
       @bucket_name = bucket_name
       @region = region
-      @endpoint = parse_endpoint(endpoint)
-      @host = @host || host || default_host(bucket_name)
+      @uri = FasterS3Url::BaseURI.new(bucket_name: bucket_name, region: region, endpoint: endpoint, host: host)
+      @host = uri.host
       @default_public = default_public
       @access_key_id = access_key_id
       @secret_access_key = secret_access_key
@@ -58,11 +57,11 @@ module FasterS3Url
         @signing_key_cache = {}
       end
 
-      @canonical_headers = "host:#{host_with_port}\n"
+      @canonical_headers = "host:#{uri.host_with_port}\n"
     end
 
     def public_url(key)
-      "#{scheme}://#{host_with_port}/#{path(key)}"
+      "#{uri.scheme}://#{uri.host_with_port}/#{path(key)}"
     end
 
     # Generates a presigned GET URL for a specified S3 object key.
@@ -156,7 +155,7 @@ module FasterS3Url
       signing_key = retrieve_signing_key(datestamp)
       signature = OpenSSL::HMAC.hexdigest("SHA256", signing_key, string_to_sign)
 
-      return scheme + "://" + host_with_port + canonical_uri + "?" + canonical_query_string + "&X-Amz-Signature=" + signature
+      return uri.scheme + "://" + uri.host_with_port + canonical_uri + "?" + canonical_query_string + "&X-Amz-Signature=" + signature
     end
 
     # just a convenience method that can call public_url or presigned_url based on flag
@@ -246,50 +245,12 @@ module FasterS3Url
       end
     end
 
-    def scheme
-      @scheme || 'https'
-    end
-
-    def host_with_port
-      [
-        host,
-        @port
-      ].compact.join(":")
-    end
-
-    def parse_endpoint(endpoint)
-      return unless endpoint
-
-      uri = URI.parse(endpoint)
-      @scheme = uri.scheme
-      @port = uri.port if uri.port && uri.default_port != uri.port
-      host = uri.host
-      host = "#{bucket_name}.#{host}" unless is_ip(host)
-      @host = host
-    end
-
-    def default_host(bucket_name)
-      if region == "us-east-1"
-        # use legacy one without region, as S3 seems to
-        "#{bucket_name}.s3.amazonaws.com".freeze
-      else
-        "#{bucket_name}.s3.#{region}.amazonaws.com".freeze
-      end
-    end
-
     def path(key)
-      if is_ip(host)
+      if uri.ip?
         "#{bucket_name}/#{uri_escape_key(key)}"
       else
         uri_escape_key(key)
       end
-    end
-
-    def is_ip(authority)
-      IPAddr.new(authority)
-      true
-    rescue IPAddr::InvalidAddressError
-      false
     end
 
     # `def get_signature_key` `from python example at https://docs.aws.amazon.com/general/latest/gr/sigv4-signed-request-examples.html

--- a/spec/base_uri_spec.rb
+++ b/spec/base_uri_spec.rb
@@ -1,0 +1,67 @@
+require 'spec_helper'
+
+RSpec.describe FasterS3Url::BaseURI do
+  let(:bucket_name) { 'my-bucket' }
+  let(:region) { 'us-east-1'}
+  let(:endpoint) { nil }
+  let(:host) { nil }
+
+  let(:subject) do
+    described_class.new(
+      bucket_name: bucket_name,
+      region: region,
+      endpoint: endpoint,
+      host: host
+    )
+  end
+
+  describe 'with the endpoint param' do
+    describe 'and the endpoint is a string' do
+      let(:endpoint) { 'http://example.com' }
+
+      it 'fetches the information for that endpoint' do
+        expect(subject.ip?).to eq false
+        expect(subject.scheme).to eq 'http'
+        expect(subject.host).to eq 'my-bucket.example.com'
+        expect(subject.host_with_port).to eq 'my-bucket.example.com'
+      end
+    end
+
+    describe 'and the endpoint is an ip address' do
+      let(:endpoint) { 'http://127.0.0.1:9000' }
+
+      it 'fetches the information for that endpoint' do
+        expect(subject.ip?).to eq true
+        expect(subject.scheme).to eq 'http'
+        expect(subject.host).to eq '127.0.0.1'
+        expect(subject.host_with_port).to eq '127.0.0.1:9000'
+      end
+    end
+  end
+
+  describe 'with the host param' do
+    describe 'and the endpoint is a string' do
+      let(:host) { 'example.com' }
+
+      it 'fetches the information for that endpoint' do
+        expect(subject.ip?).to eq false
+        expect(subject.scheme).to eq 'https'
+        expect(subject.host).to eq 'example.com'
+        expect(subject.host_with_port).to eq 'example.com'
+      end
+    end
+
+    describe 'and an endpoint param' do
+      let(:host) { 'example.com' }
+      let(:endpoint) { 'http://127.0.0.1:9000' }
+
+      it 'fetches the information for that endpoint, and ignores the host' do
+        expect(subject.ip?).to eq true
+        expect(subject.scheme).to eq 'http'
+        expect(subject.host).to eq '127.0.0.1'
+        expect(subject.host_with_port).to eq '127.0.0.1:9000'
+      end
+    end
+  end
+
+end


### PR DESCRIPTION
https://github.com/jrochkind/faster_s3_url/issues/9

Currently the `Builder`'s initializer accepts a `host` param which assumes https. I like to use minio for local development and it isn't ideal to run it with `https`.

The normal Aws::S3::Client gem accepts an `:endpoint` option to by-pass this issue.

Here is a section of the docs that explains this option:

```
:endpoint (String, URI::HTTPS, URI::HTTP) — Normally you should not configure the :endpoint option directly. This is normally constructed from the :region option. Configuring :endpoint is normally reserved for connecting to test or custom endpoints. The endpoint should be a URI formatted like:
'http://example.com'
'https://example.com'
'http://example.com:123'
```
https://docs.aws.amazon.com/sdk-for-ruby/v3/api/Aws/S3/Client.html


## Performance tests

<details>

<summary>public_bench -- this branch</summary>

``` 
ruby 3.1.0p0 (2021-12-25 revision fb4df44d16) [x86_64-darwin19]
Warming up --------------------------------------
          aws-sdk-s3     2.311k i/100ms
         FasterS3Url    32.292k i/100ms
Calculating -------------------------------------
          aws-sdk-s3     23.427k (± 0.9%) i/s   (42.69 μs/i) -    117.861k in   5.037506s
         FasterS3Url    325.072k (± 0.5%) i/s    (3.08 μs/i) -      1.647M in   5.068149s
                   with 95.0% confidence
```

</details>


<details>

<summary>presigned_bench -- this branch</summary>

``` 
ruby 3.1.0p0 (2021-12-25 revision fb4df44d16) [x86_64-darwin19]
Warming up --------------------------------------
          aws-sdk-s3   143.000 i/100ms
aws-sdk-s3 with custom headers
                       156.000 i/100ms
 re-used FasterS3Url     2.652k i/100ms
re-used FasterS3Url with cached signing keys
                         4.336k i/100ms
re-used FasterS3URL with custom headers
                         1.954k i/100ms
new FasterS3URL Builder each time
                         1.930k i/100ms
re-used WT::S3Signer     8.772k i/100ms
new WT::S3Signer each time
                         2.354k i/100ms
Calculating -------------------------------------
          aws-sdk-s3      1.582k (± 2.0%) i/s  (631.98 μs/i) -      7.865k in   5.002142s
aws-sdk-s3 with custom headers
                          1.480k (± 2.4%) i/s  (675.47 μs/i) -      7.488k in   5.100616s
 re-used FasterS3Url     25.842k (± 0.8%) i/s   (38.70 μs/i) -    129.948k in   5.032903s
re-used FasterS3Url with cached signing keys
                         39.025k (± 2.3%) i/s   (25.62 μs/i) -    195.120k in   5.030891s
re-used FasterS3URL with custom headers
                         19.703k (± 2.0%) i/s   (50.75 μs/i) -     99.654k in   5.087072s
new FasterS3URL Builder each time
                         21.853k (± 1.8%) i/s   (45.76 μs/i) -    110.010k in   5.059017s
re-used WT::S3Signer     89.431k (± 2.0%) i/s   (11.18 μs/i) -    447.372k in   5.025458s
new WT::S3Signer each time
                         26.529k (± 2.1%) i/s   (37.69 μs/i) -    131.824k in   5.006578s
                   with 95.0% confidence
```

</details>


<details>

<summary>public_bench -- on v1.1 of the project</summary>

``` 
ruby 3.1.0p0 (2021-12-25 revision fb4df44d16) [x86_64-darwin19]
Warming up --------------------------------------
          aws-sdk-s3     2.354k i/100ms
         FasterS3Url    42.537k i/100ms
Calculating -------------------------------------
          aws-sdk-s3     24.112k (± 0.8%) i/s   (41.47 μs/i) -    122.408k in   5.082080s
         FasterS3Url    443.088k (± 0.7%) i/s    (2.26 μs/i) -      2.254M in   5.092750s
                   with 95.0% confidence
```

</details>

<details>

<summary>presigned_bench.rb -- on v1.1 of the project</summary>

``` 
ruby 3.1.0p0 (2021-12-25 revision fb4df44d16) [x86_64-darwin19]
Warming up --------------------------------------
          aws-sdk-s3   149.000 i/100ms
aws-sdk-s3 with custom headers
                       137.000 i/100ms
 re-used FasterS3Url     2.429k i/100ms
re-used FasterS3Url with cached signing keys
                         4.155k i/100ms
re-used FasterS3URL with custom headers
                         2.154k i/100ms
new FasterS3URL Builder each time
                         2.299k i/100ms
re-used WT::S3Signer     8.976k i/100ms
new WT::S3Signer each time
                         2.419k i/100ms
Calculating -------------------------------------
          aws-sdk-s3      1.571k (± 2.0%) i/s  (636.63 μs/i) -      7.897k in   5.054203s
aws-sdk-s3 with custom headers
                          1.540k (± 1.5%) i/s  (649.54 μs/i) -      7.672k in   5.002016s
 re-used FasterS3Url     26.317k (± 0.9%) i/s   (38.00 μs/i) -    133.595k in   5.082447s
re-used FasterS3Url with cached signing keys
                         46.601k (± 2.0%) i/s   (21.46 μs/i) -    232.680k in   5.030958s
re-used FasterS3URL with custom headers
                         22.195k (± 1.4%) i/s   (45.06 μs/i) -    112.008k in   5.064084s
new FasterS3URL Builder each time
                         25.327k (± 1.1%) i/s   (39.48 μs/i) -    126.445k in   5.003145s
re-used WT::S3Signer    100.899k (± 1.2%) i/s    (9.91 μs/i) -    511.632k in   5.084384s
new WT::S3Signer each time
                         27.649k (± 0.7%) i/s   (36.17 μs/i) -    140.302k in   5.078609s
                   with 95.0% confidence
```

</details>