### PR TITLE
Add support for session_token

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+
+- Add `session_token` option to `Builder` from [@BenKanouse](https://github.com/BenKanouse) https://github.com/jrochkind/faster_s3_url/pull/12
+
 ## 1.1.0
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -75,6 +75,20 @@ builder = FasterS3Url::Builder.new(
 builder.presign_url(key) # performance enhanced
 ```
 
+### Using AWS Security Token Service (AWS STS)?
+
+When using AWS Security Token Service (AWS STS), AWS requires that the X-Amz-Security-Token parameter is set on presigned URLs. To accomplish this, you will need to pass the optional `session_token` parameter into the `FasterS3Url::Builder`.
+
+```ruby
+builder = FasterS3Url::Builder.new(
+  bucket_name: "my-bucket.example.com",
+  region: "us-east-1",
+  access_key_id: ENV['AWS_ACCESS_KEY'],
+  secret_access_key: ENV['AWS_SECRET_KEY'],
+  session_token: "session_token"
+)
+builder.presign_url(key) # includes required X-Amz-Security-Token
+```
 
 ### Automatic AWS credentials lookup?
 
@@ -90,6 +104,7 @@ credentials = credentials.credentials if credentials.respond_to?(:credentials)
 
 access_key_id     = credentials.access_key_id
 secret_access_key = credentials.secret_access_key
+session_token     = credentials.session_token # only needed when using AWS Security Token Service
 region            = client.config.region
 ```
 

--- a/spec/builder_spec.rb
+++ b/spec/builder_spec.rb
@@ -6,13 +6,14 @@ require 'aws-sdk-s3'
 RSpec.describe FasterS3Url do
   let(:access_key_id) { "fakeExampleAccessKeyId"}
   let(:secret_access_key) { "fakeExampleSecretAccessKey" }
+  let(:session_token) { nil }
 
   let(:bucket_name) { "my-bucket" }
   let(:object_key) { "some/directory/file.jpg" }
   let(:region) { "us-east-1"}
   let(:host) { nil }
 
-  let(:aws_client) { Aws::S3::Client.new(region: region, access_key_id: access_key_id, secret_access_key: secret_access_key) }
+  let(:aws_client) { Aws::S3::Client.new(region: region, access_key_id: access_key_id, secret_access_key: secret_access_key, session_token: session_token) }
   let(:aws_bucket) { Aws::S3::Bucket.new(name: bucket_name, client: aws_client)}
 
   let(:builder) {
@@ -20,7 +21,8 @@ RSpec.describe FasterS3Url do
                               region: region,
                               host: host,
                               access_key_id: access_key_id,
-                              secret_access_key: secret_access_key)
+                              secret_access_key: secret_access_key,
+                              session_token: session_token)
   }
 
   describe "#public_url" do
@@ -85,9 +87,17 @@ RSpec.describe FasterS3Url do
         expect(builder.presigned_url(object_key)).to eq(aws_bucket.object(object_key).presigned_url(:get))
       end
 
+      describe "custom session_token" do
+        let(:session_token) { 'custom_session_token' }
+
+        it "produces same as aws-sdk" do
+          expect(builder.presigned_url(object_key)).to eq(aws_bucket.object(object_key).presigned_url(:get))
+        end
+      end
+
       describe "custom expires_in" do
         let(:expires_in) { 4 * 24 * 60 * 60}
-        it "produces saem as aws-sdk" do
+        it "produces same as aws-sdk" do
           expect(builder.presigned_url(object_key, expires_in: expires_in)).to eq(aws_bucket.object(object_key).presigned_url(:get, expires_in: expires_in))
         end
 


### PR DESCRIPTION
If a user is authenticating to S3 using a temporary security token that was obtained through a call to AWS Security Token Service, the S3::Client allows a user to set the `session_token` option. In AWS this option ends up setting the `X-Amz-Security-Token` param in the url.

This commit adds support to the FasterS3Url::Builder that allows a user to set a `session_token` which will intern set the `X-Amz-Security-Token` param in the url.

The specs added confirm it matches the behavior in when a session_token is added to the `Aws::S3::Client` class.

Performance tests:

<details>

<summary>presigned_bench -- This commit</summary>

```
ruby 3.1.0p0 (2021-12-25 revision fb4df44d16) [x86_64-darwin19]
Warming up --------------------------------------
          aws-sdk-s3   170.000 i/100ms
aws-sdk-s3 with custom headers
                       158.000 i/100ms
 re-used FasterS3Url     2.492k i/100ms
re-used FasterS3Url with cached signing keys
                         3.491k i/100ms
re-used FasterS3URL with custom headers
                         2.047k i/100ms
new FasterS3URL Builder each time
                         2.193k i/100ms
re-used WT::S3Signer    10.272k i/100ms
new WT::S3Signer each time
                         2.850k i/100ms
Calculating -------------------------------------
          aws-sdk-s3      1.748k (± 1.5%) i/s  (572.04 μs/i) -      8.840k in   5.077587s
aws-sdk-s3 with custom headers
                          1.579k (± 1.3%) i/s  (633.47 μs/i) -      7.900k in   5.018456s
 re-used FasterS3Url     24.679k (± 0.8%) i/s   (40.52 μs/i) -    124.600k in   5.054031s
re-used FasterS3Url with cached signing keys
                         42.433k (± 0.7%) i/s   (23.57 μs/i) -    212.951k in   5.023465s
re-used FasterS3URL with custom headers
                         21.973k (± 0.7%) i/s   (45.51 μs/i) -    110.538k in   5.034977s
new FasterS3URL Builder each time
                         23.888k (± 0.6%) i/s   (41.86 μs/i) -    120.615k in   5.051815s
re-used WT::S3Signer    102.459k (± 0.9%) i/s    (9.76 μs/i) -    513.600k in   5.019763s
new WT::S3Signer each time
                         25.473k (± 2.5%) i/s   (39.26 μs/i) -    128.250k in   5.074233s
                   with 95.0% confidence
```
</details>

<details>

<summary>presigned_bench -- v1.1</summary>

```
ruby 3.1.0p0 (2021-12-25 revision fb4df44d16) [x86_64-darwin19]
Warming up --------------------------------------
          aws-sdk-s3   173.000 i/100ms
aws-sdk-s3 with custom headers
                       157.000 i/100ms
 re-used FasterS3Url     2.656k i/100ms
re-used FasterS3Url with cached signing keys
                         4.581k i/100ms
re-used FasterS3URL with custom headers
                         2.222k i/100ms
new FasterS3URL Builder each time
                         2.552k i/100ms
re-used WT::S3Signer    10.121k i/100ms
new WT::S3Signer each time
                         2.780k i/100ms
Calculating -------------------------------------
          aws-sdk-s3      1.756k (± 1.3%) i/s  (569.38 μs/i) -      8.823k in   5.036679s
aws-sdk-s3 with custom headers
                          1.552k (± 1.7%) i/s  (644.22 μs/i) -      7.850k in   5.080740s
 re-used FasterS3Url     25.827k (± 1.9%) i/s   (38.72 μs/i) -    130.144k in   5.068917s
re-used FasterS3Url with cached signing keys
                         45.096k (± 2.4%) i/s   (22.17 μs/i) -    224.469k in   5.021065s
re-used FasterS3URL with custom headers
                         21.216k (± 1.5%) i/s   (47.13 μs/i) -    106.656k in   5.042634s
new FasterS3URL Builder each time
                         25.391k (± 1.0%) i/s   (39.38 μs/i) -    127.600k in   5.032678s
re-used WT::S3Signer     95.345k (± 1.8%) i/s   (10.49 μs/i) -    475.687k in   5.011579s
new WT::S3Signer each time
                         26.239k (± 2.2%) i/s   (38.11 μs/i) -    130.660k in   5.010333s
                   with 95.0% confidence
```

</details>