### PR TITLE
Add endpoint option to Builder

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Add `session_token` option to `Builder` from [@BenKanouse](https://github.com/BenKanouse) https://github.com/jrochkind/faster_s3_url/pull/12
 
+- Add 'endpoint' option to Builder, thanks @BenKanouse, https://github.com/jrochkind/faster_s3_url/pull/14
+
 ## 1.1.0
 
 ### Fixed

--- a/lib/faster_s3_url/builder.rb
+++ b/lib/faster_s3_url/builder.rb
@@ -240,19 +240,16 @@ module FasterS3Url
     #
     # Set base_url correct for host or endpoint.
     def parsed_base_uri(bucket_name:, host:, endpoint:)
-      if host
-        return URI.parse("https://#{host}")
-      elsif endpoint
-        parsed = URI.parse(endpoint)
-        if parsed.host =~ /\A\d+\.\d+\.\d+\.\d+\Z/
-          parsed.path = "/#{bucket_name}"
-        else
-          parsed.host = "#{bucket_name}.#{parsed.host}"
-        end
-        return parsed
+      return URI.parse("https://#{host}") if host
+      return URI.parse("https://#{default_host(bucket_name)}") if endpoint.nil?
+
+      parsed = URI.parse(endpoint)
+      if parsed.host =~ /\A\d+\.\d+\.\d+\.\d+\Z/
+        parsed.path = "/#{bucket_name}"
       else
-        return URI.parse("https://#{default_host(bucket_name)}")
+        parsed.host = "#{bucket_name}.#{parsed.host}"
       end
+      parsed
     end
 
     def default_host(bucket_name)

--- a/lib/faster_s3_url/builder.rb
+++ b/lib/faster_s3_url/builder.rb
@@ -20,7 +20,8 @@ module FasterS3Url
 
     MAX_CACHED_SIGNING_KEYS = 5
 
-    attr_reader :bucket_name, :region, :host, :base_url, :base_path, :access_key_id, :session_token
+    attr_reader :bucket_name, :region, :host, :access_key_id, :session_token
+    private attr_reader :base_url, :base_path
 
     # @option params [String] :bucket_name required
     #


### PR DESCRIPTION
Resolves #9, alternate approach to #10

endpoint can be useful for eg local minio, or perhaps other S3 clones.

Here is a section of the docs that explains this option:

```
:endpoint (String, URI::HTTPS, URI::HTTP) — Normally you should not configure the :endpoint option directly. This is normally constructed from the :region option. Configuring :endpoint is normally reserved for connecting to test or custom endpoints. The endpoint should be a URI formatted like:
'http://example.com'
'https://example.com'
'http://example.com:123'
```
https://docs.aws.amazon.com/sdk-for-ruby/v3/api/Aws/S3/Client.html

Thanks @BenKanouse , I could not have done this without your specs and working implementation to comapre to! 

It may just be an issue of aesthetics -- your appraoch was a nice OO design, but I just prefer doing it this way, where all calculations happen once at object initialization, and thereafter it's just simple string concatenation of the things we pre-calced.  To me this is simpler and easier to follow, although I could see an argument either way. 

Do you want to review and/or test this and see if it meets your needs?  If so, I'll merge, and do a release soon. 
